### PR TITLE
Fix Up arrow and most F keys, etc.

### DIFF
--- a/readchar/__init__.py
+++ b/readchar/__init__.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# This file is based on this gist:
+# http://code.activestate.com/recipes/134892/
+# So real authors are DannyYoo and company.
+
 from .readchar import readchar, readkey
 from . import key
 

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# This file is based on this gist:
+# http://code.activestate.com/recipes/134892/
+# So real authors are DannyYoo and company.
+
 # common
 LF = '\x0d'
 CR = '\x0a'
@@ -5,7 +10,13 @@ ENTER = '\x0d'
 BACKSPACE = '\x7f'
 SUPR = ''
 SPACE = '\x20'
+
 ESC = '\x1b'
+
+# Silly, but ESC key cannot be detected by itself, it must be pressed twice
+# pressing the literal "Esc - [ - A" sequence on a (linux, anyway) keyboard
+# is the exact same as pressing UP arrow!
+ESC_KEY = ESC
 
 # CTRL
 CTRL_A = '\x01'
@@ -35,14 +46,17 @@ F1 = '\x1b\x4f\x50'
 F2 = '\x1b\x4f\x51'
 F3 = '\x1b\x4f\x52'
 F4 = '\x1b\x4f\x53'
-F5 = '\x1b\x4f\x31\x35\x7e'
-F6 = '\x1b\x4f\x31\x37\x7e'
-F7 = '\x1b\x4f\x31\x38\x7e'
-F8 = '\x1b\x4f\x31\x39\x7e'
-F9 = '\x1b\x4f\x32\x30\x7e'
-F10 = '\x1b\x4f\x32\x31\x7e'
-F11 = '\x1b\x4f\x32\x33\x7e'
-F12 = '\x1b\x4f\x32\x34\x7e'
+F5 = '\x1b\x5b\x31\x35\x7e'
+F6 = '\x1b\x5b\x31\x37\x7e'
+F7 = '\x1b\x5b\x31\x38\x7e'
+F8 = '\x1b\x5b\x31\x39\x7e'
+F9 = '\x1b\x5b\x32\x30\x7e'
+F10 = '\x1b\x5b\x32\x31\x7e'
+
+# we can't get these because the code can't presently tell if the 5th '\x7e'
+# should expect another character or not!
+F11 = '\x1b\x5b\x32\x33\x7e\x1b'
+F12 = '\x1b\x5b\x32\x34\x7e\x08'
 
 PAGE_UP = '\x1b\x5b\x35\x7e'
 PAGE_DOWN = '\x1b\x5b\x36\x7e'
@@ -50,8 +64,11 @@ HOME = '\x1b\x5b\x48'
 END = '\x1b\x5b\x46'
 
 INSERT = '\x1b\x5b\x32\x7e'
-SUPR = '\x1b\x5b\x33\x7e'
 
+# what's this?  Why is it defined to '' in above Line 11?
+# why is it the same as DELETE?
+SUPR = '\x1b\x5b\x33\x7e'
+DELETE = '\x1b\x5b\x33\x7e'
 
 ESCAPE_SEQUENCES = (
     ESC,

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
-# This file is based on this gist:
-# http://code.activestate.com/recipes/134892/
-# So real authors are DannyYoo and company.
+
 
 # common
 LF = '\x0d'
 CR = '\x0a'
 ENTER = '\x0d'
 BACKSPACE = '\x7f'
-SUPR = ''
 SPACE = '\x20'
 
 ESC = '\x1b'

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -62,8 +62,6 @@ END = '\x1b\x5b\x46'
 
 INSERT = '\x1b\x5b\x32\x7e'
 
-# what's this?  Why is it defined to '' in above Line 11?
-# why is it the same as DELETE?
 SUPR = '\x1b\x5b\x33\x7e'
 DELETE = '\x1b\x5b\x33\x7e'
 

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -21,7 +21,7 @@ def readkey(getchar_fn=None):
     if ord(c1) != 0x1b:
         return c1
     c2 = getchar()
-    if ord(c2) not in (0x5b, 0x4f):
+    if ord(c2) not in 0x5b:
         return c1 + c2
     c3 = getchar()
     if ord(c3) not in (0x31, 0x32, 0x33, 0x35, 0x36):

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -21,7 +21,7 @@ def readkey(getchar_fn=None):
     if ord(c1) != 0x1b:
         return c1
     c2 = getchar()
-    if ord(c2) not in 0x5b:
+    if ord(c2) != 0x5b:
         return c1 + c2
     c3 = getchar()
     if ord(c3) not in (0x31, 0x32, 0x33, 0x35, 0x36):

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -21,10 +21,13 @@ def readkey(getchar_fn=None):
     if ord(c1) != 0x1b:
         return c1
     c2 = getchar()
-    if ord(c2) != 0x5b:
+    if ord(c2) not in (0x5b, 0x4f):
         return c1 + c2
     c3 = getchar()
-    if ord(c3) != 0x33:
+    if ord(c3) not in (0x31, 0x32, 0x33, 0x35, 0x36):
         return c1 + c2 + c3
     c4 = getchar()
-    return c1 + c2 + c3 + c4
+    if ord(c4) not in (0x30, 0x31, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39):
+        return c1 + c2 + c3 + c4
+    c5 = getchar()
+    return c1 + c2 + c3 + c4 + c5

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -21,7 +21,7 @@ def readkey(getchar_fn=None):
     if ord(c1) != 0x1b:
         return c1
     c2 = getchar()
-    if ord(c2) != 0x5b:
+    if ord(c2) not in (0x5b, 0x4f):
         return c1 + c2
     c3 = getchar()
     if ord(c3) not in (0x31, 0x32, 0x33, 0x35, 0x36):

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -8,7 +8,6 @@ import tty
 import termios
 
 
-
 def readchar():
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
-# Initially taken from:
+# This file is based on this gist:
 # http://code.activestate.com/recipes/134892/
-# Thanks to Danny Yoo
+# So real authors are DannyYoo and company.
+
 import sys
 import tty
 import termios
+
 
 
 def readchar():
@@ -15,4 +17,8 @@ def readchar():
         ch = sys.stdin.read(1)
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+    # useful for debugging and viewing codes
+    # print(ch, ord(ch).__hex__())
+
     return ch

--- a/readchar/readchar_windows.py
+++ b/readchar/readchar_windows.py
@@ -6,7 +6,7 @@ import msvcrt
 
 
 def readchar(blocking=False):
-    "Get a single character on Windows."
+    """Get a single character on Windows."""
 
     while msvcrt.kbhit():
         msvcrt.getch()


### PR DESCRIPTION
Per my other message, https://github.com/magmax/python-readchar/issues/20#issuecomment-286588396

#1 way was the best I can manage for now!

This works (but I am not sure I need to have the `\x4f\ now since that is not actually part of the F key codes. (at least not on linux?) 

 EDIT: removed the `\x4f\` checking too..
2ND EDIT: re-added the `\x4f\` for F1-F4.