### PR TITLE
Version 0.12.0?  used 12 because 11 was last used.

### DIFF
--- a/readchar/__init__.py
+++ b/readchar/__init__.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# This file is based on this gist:
+# http://code.activestate.com/recipes/134892/
+# So real authors are DannyYoo and company.
+
 from .readchar import readchar, readkey
 from . import key
 

--- a/readchar/__init__.py
+++ b/readchar/__init__.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-# This file is based on this gist:
+# Copyright (c) 2014 - 2017 Miguel Ángel García (@magmax9).
+# Licensed under the MIT license.
+# This package was inspired this gist:
 # http://code.activestate.com/recipes/134892/
-# So real authors are DannyYoo and company.
+# A debt of gratitute belongs to DannyYoo and company.
 
 from .readchar import readchar, readkey
 from . import key
 
 __all__ = [readchar, readkey, key]
 
-__version__ = '0.0.8'
+__version__ = '0.12.0'

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-
+# Copyright (c) 2014 - 2017 Miguel Ángel García (@magmax9).
 
 # common
+TAB = '\x09'
 LF = '\x0d'
 CR = '\x0a'
 ENTER = '\x0d'
@@ -49,9 +50,6 @@ F7 = '\x1b\x5b\x31\x38\x7e'
 F8 = '\x1b\x5b\x31\x39\x7e'
 F9 = '\x1b\x5b\x32\x30\x7e'
 F10 = '\x1b\x5b\x32\x31\x7e'
-
-# we can't get these because the code can't presently tell if the 5th '\x7e'
-# should expect another character or not!
 F11 = '\x1b\x5b\x32\x33\x7e\x1b'
 F12 = '\x1b\x5b\x32\x34\x7e\x08'
 
@@ -64,6 +62,70 @@ INSERT = '\x1b\x5b\x32\x7e'
 
 SUPR = '\x1b\x5b\x33\x7e'
 DELETE = '\x1b\x5b\x33\x7e'
+
+# text names for keys
+KEYS = {
+    CR: 'cr',
+    TAB: 'tab',
+    ENTER: 'enter',
+    BACKSPACE: 'backspace',
+    ESC: 'escape',
+    UP: 'up',
+    RIGHT: 'right',
+    DOWN: 'down',
+    LEFT: 'left',
+    PAGE_UP: 'page_up',
+    PAGE_DOWN: 'page_down',
+    F1: 'f1',
+    F2: 'f2',
+    F3: 'f3',
+    F4: 'f4',
+    F5: 'f5',
+    F6: 'f6',
+    F7: 'f7',
+    F8: 'f8',
+    F9: 'f9',
+    F10: 'f10',
+    DELETE: 'delete',
+    CTRL_A: 'ctrl_a',
+    CTRL_B: 'ctrl_b',
+    CTRL_C: 'ctrl_c',
+    CTRL_D: 'ctrl_d',
+    CTRL_E: 'ctrl_e',
+    CTRL_F: 'ctrl_f',
+    CTRL_Z: 'ctrl_z',
+    INSERT: 'insert',
+    SUPR: 'supr',
+    CTRL_ALT_A: 'ctrl_alt_a'
+}
+
+windows_keys = {
+    '\\x1b': ESC,
+    '\\x85': F11,
+    '\\x86': F12,
+    '\\x08': BACKSPACE,
+    '\\r': ENTER,
+    '\\t': TAB,
+}
+
+windows_special_keys = {
+    # Single keys:
+    'H': UP,
+    'M': RIGHT,
+    'P': DOWN,
+    'K': LEFT,
+    ';': F1,
+    '<': F2,
+    '=': F3,
+    '>': F4,
+    '?': F5,
+    '@': F6,
+    'A': F7,
+    'B': F8,
+    'C': F9,
+    'D': F10,
+    'S': DELETE,
+}
 
 ESCAPE_SEQUENCES = (
     ESC,
@@ -83,9 +145,17 @@ ESCAPE_SEQUENCES = (
     ESC + '\x5b' + '\x32' + '\x32',
     ESC + '\x5b' + '\x32' + '\x33',
     ESC + '\x5b' + '\x32' + '\x34',
+    ESC + '\x5b' + '\x32' + '\x33' + '\x7e',
+    ESC + '\x5b' + '\x32' + '\x34' + '\x7e',
     ESC + '\x4f',
     ESC + ESC,
     ESC + ESC + '\x5b',
     ESC + ESC + '\x5b' + '\x32',
     ESC + ESC + '\x5b' + '\x33',
 )
+
+
+def convertchar(charbuffer):
+    if charbuffer in KEYS:
+        return KEYS[charbuffer]
+    return charbuffer

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# This file is based on this gist:
+# http://code.activestate.com/recipes/134892/
+# So real authors are DannyYoo and company.
+
 # common
 LF = '\x0d'
 CR = '\x0a'
@@ -5,7 +10,13 @@ ENTER = '\x0d'
 BACKSPACE = '\x7f'
 SUPR = ''
 SPACE = '\x20'
+
 ESC = '\x1b'
+
+# Silly, but ESC key cannot be detected by itself, it must be pressed twice
+# pressing the literal "Esc - [ - A" sequence on a (linux, anyway) keyboard
+# is the exact same as pressing UP arrow!
+ESC_KEY = ESC
 
 # CTRL
 CTRL_A = '\x01'
@@ -35,14 +46,17 @@ F1 = '\x1b\x4f\x50'
 F2 = '\x1b\x4f\x51'
 F3 = '\x1b\x4f\x52'
 F4 = '\x1b\x4f\x53'
-F5 = '\x1b\x4f\x31\x35\x7e'
-F6 = '\x1b\x4f\x31\x37\x7e'
-F7 = '\x1b\x4f\x31\x38\x7e'
-F8 = '\x1b\x4f\x31\x39\x7e'
-F9 = '\x1b\x4f\x32\x30\x7e'
-F10 = '\x1b\x4f\x32\x31\x7e'
-F11 = '\x1b\x4f\x32\x33\x7e'
-F12 = '\x1b\x4f\x32\x34\x7e'
+F5 = '\x1b\x5b\x31\x35\x7e'
+F6 = '\x1b\x5b\x31\x37\x7e'
+F7 = '\x1b\x5b\x31\x38\x7e'
+F8 = '\x1b\x5b\x31\x39\x7e'
+F9 = '\x1b\x5b\x32\x30\x7e'
+F10 = '\x1b\x5b\x32\x31\x7e'
+
+# we can't get these because the code can't presently tell if the 5th '\x7e'
+# should expect another character or not!
+F11 = '\x1b\x5b\x32\x33\x7e\x1b'
+F12 = '\x1b\x5b\x32\x34\x7e\x08'
 
 PAGE_UP = '\x1b\x5b\x35\x7e'
 PAGE_DOWN = '\x1b\x5b\x36\x7e'
@@ -50,8 +64,11 @@ HOME = '\x1b\x5b\x48'
 END = '\x1b\x5b\x46'
 
 INSERT = '\x1b\x5b\x32\x7e'
-SUPR = '\x1b\x5b\x33\x7e'
 
+# what's this?  Why is it defined to '' in above Line 11?
+# why is it the same as DELETE?
+SUPR = '\x1b\x5b\x33\x7e'
+DELETE = '\x1b\x5b\x33\x7e'
 
 ESCAPE_SEQUENCES = (
     ESC,

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
-# This file is based on this gist:
-# http://code.activestate.com/recipes/134892/
-# So real authors are DannyYoo and company.
+
 
 # common
 LF = '\x0d'
 CR = '\x0a'
 ENTER = '\x0d'
 BACKSPACE = '\x7f'
-SUPR = ''
 SPACE = '\x20'
 
 ESC = '\x1b'

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -81,7 +81,8 @@ KEYS = {
     F8: 'f8',
     F9: 'f9',
     F10: 'f10',
-    DELETE: 'delete',
+    F11: 'f11',
+    F12: 'f12',
     CTRL_A: 'ctrl_a',
     CTRL_B: 'ctrl_b',
     CTRL_C: 'ctrl_c',
@@ -91,6 +92,7 @@ KEYS = {
     CTRL_Z: 'ctrl_z',
     INSERT: 'insert',
     SUPR: 'supr',
+    DELETE: 'delete',
     CTRL_ALT_A: 'ctrl_alt_a'
 }
 

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -62,8 +62,6 @@ END = '\x1b\x5b\x46'
 
 INSERT = '\x1b\x5b\x32\x7e'
 
-# what's this?  Why is it defined to '' in above Line 11?
-# why is it the same as DELETE?
 SUPR = '\x1b\x5b\x33\x7e'
 DELETE = '\x1b\x5b\x33\x7e'
 

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -71,6 +71,8 @@ KEYS = {
     LEFT: 'left',
     PAGE_UP: 'page_up',
     PAGE_DOWN: 'page_down',
+    HOME: 'home',
+    END: 'end',
     F1: 'f1',
     F2: 'f2',
     F3: 'f3',

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -7,14 +7,7 @@ LF = '\x0d'
 CR = '\x0a'
 ENTER = '\x0d'
 BACKSPACE = '\x7f'
-SPACE = '\x20'
-
 ESC = '\x1b'
-
-# Silly, but ESC key cannot be detected by itself, it must be pressed twice
-# pressing the literal "Esc - [ - A" sequence on a (linux, anyway) keyboard
-# is the exact same as pressing UP arrow!
-ESC_KEY = ESC
 
 # CTRL
 CTRL_A = '\x01'
@@ -60,6 +53,8 @@ END = '\x1b\x5b\x46'
 
 INSERT = '\x1b\x5b\x32\x7e'
 
+# SUPR and DELETE are the same key, but for different
+# keyboards (Esp. vs Eng/USA)
 SUPR = '\x1b\x5b\x33\x7e'
 DELETE = '\x1b\x5b\x33\x7e'
 

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -19,6 +19,6 @@ else:
 
 
 def readkey(getchar_func=get_char):
-    getchar = getchar_func #  or readchar
+    getchar = getchar_func or readchar
     charbuffer = getchar()
     return charbuffer

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -21,7 +21,7 @@ def readkey(getchar_fn=None):
     if ord(c1) != 0x1b:
         return c1
     c2 = getchar()
-    if ord(c2) not in (0x5b, 0x4f):
+    if ord(c2) not in 0x5b:
         return c1 + c2
     c3 = getchar()
     if ord(c3) not in (0x31, 0x32, 0x33, 0x35, 0x36):

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -19,6 +19,6 @@ else:
 
 
 def readkey(getchar_func=get_char):
-    getchar = getchar_func or readchar
+    getchar = getchar_func #  or readchar
     charbuffer = getchar()
     return charbuffer

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -18,7 +18,6 @@ else:
     raise NotImplemented('The platform %s is not supported yet' % sys.platform)
 
 
-def readkey(getchar_func=get_char):
-    getchar = getchar_func or readchar
-    charbuffer = getchar()
+def readkey(test_stream=None):
+    charbuffer = get_char(test_stream)
     return charbuffer

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -18,7 +18,7 @@ else:
     raise NotImplemented('The platform %s is not supported yet' % sys.platform)
 
 
-def readkey(getchar_fn=get_char):
-    getchar = getchar_fn or readchar
+def readkey(getchar_func=get_char):
+    getchar = getchar_func or readchar
     charbuffer = getchar()
     return charbuffer

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -21,7 +21,7 @@ def readkey(getchar_fn=None):
     if ord(c1) != 0x1b:
         return c1
     c2 = getchar()
-    if ord(c2) not in 0x5b:
+    if ord(c2) != 0x5b:
         return c1 + c2
     c3 = getchar()
     if ord(c3) not in (0x31, 0x32, 0x33, 0x35, 0x36):

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -13,7 +13,8 @@ if sys.platform.startswith('linux'):
 elif sys.platform == 'darwin':
     from .readchar_linux import readchar, get_char
 elif sys.platform in ('win32', 'cygwin'):
-    from .readchar_windows import readchar, get_char
+    from .readchar_windows import readchar
+    get_char = None
 else:
     raise NotImplemented('The platform %s is not supported yet' % sys.platform)
 

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -21,10 +21,13 @@ def readkey(getchar_fn=None):
     if ord(c1) != 0x1b:
         return c1
     c2 = getchar()
-    if ord(c2) != 0x5b:
+    if ord(c2) not in (0x5b, 0x4f):
         return c1 + c2
     c3 = getchar()
-    if ord(c3) != 0x33:
+    if ord(c3) not in (0x31, 0x32, 0x33, 0x35, 0x36):
         return c1 + c2 + c3
     c4 = getchar()
-    return c1 + c2 + c3 + c4
+    if ord(c4) not in (0x30, 0x31, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39):
+        return c1 + c2 + c3 + c4
+    c5 = getchar()
+    return c1 + c2 + c3 + c4 + c5

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -1,33 +1,24 @@
 # -*- coding: utf-8 -*-
-# This file is based on this gist:
-# http://code.activestate.com/recipes/134892/
-# So real authors are DannyYoo and company.
+# Copyright (c) 2014- 2017 Miguel Ángel García (@magmax9).
+# Based on previous work on gist getch()-like unbuffered character
+# reading from stdin on both Windows and Unix (Python recipe),
+# started by Danny Yoo. Licensed under the MIT license.
+
+from __future__ import absolute_import
 import sys
 
 
 if sys.platform.startswith('linux'):
-    from .readchar_linux import readchar
+    from .readchar_linux import readchar, get_char
 elif sys.platform == 'darwin':
-    from .readchar_linux import readchar
+    from .readchar_linux import readchar, get_char
 elif sys.platform in ('win32', 'cygwin'):
-    from .readchar_windows import readchar
+    from .readchar_windows import readchar, get_char
 else:
     raise NotImplemented('The platform %s is not supported yet' % sys.platform)
 
 
-def readkey(getchar_fn=None):
+def readkey(getchar_fn=get_char):
     getchar = getchar_fn or readchar
-    c1 = getchar()
-    if ord(c1) != 0x1b:
-        return c1
-    c2 = getchar()
-    if ord(c2) not in (0x5b, 0x4f):
-        return c1 + c2
-    c3 = getchar()
-    if ord(c3) not in (0x31, 0x32, 0x33, 0x35, 0x36):
-        return c1 + c2 + c3
-    c4 = getchar()
-    if ord(c4) not in (0x30, 0x31, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39):
-        return c1 + c2 + c3 + c4
-    c5 = getchar()
-    return c1 + c2 + c3 + c4 + c5
+    charbuffer = getchar()
+    return charbuffer

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -8,12 +8,11 @@ from __future__ import absolute_import
 import sys
 
 
-if sys.platform.startswith('linux'):
-    from .readchar_linux import readchar, get_char
-elif sys.platform == 'darwin':
-    from .readchar_linux import readchar, get_char
-elif sys.platform in ('win32', 'cygwin'):
-    from .readchar_windows import readchar, get_char
+platform = sys.platform[0:5]
+if platform in ("linux", "darwi"):
+    from .readchar_linux import get_char, read_char
+elif platform in ('win32', 'cygwin'):
+    from .readchar_windows import get_char, read_char
 else:
     raise NotImplemented('The platform %s is not supported yet' % sys.platform)
 
@@ -21,3 +20,7 @@ else:
 def readkey(test_stream=None):
     charbuffer = get_char(test_stream)
     return charbuffer
+
+
+def readchar(blocking=True):
+    return read_char(blocking)

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -21,7 +21,7 @@ def readkey(getchar_fn=None):
     if ord(c1) != 0x1b:
         return c1
     c2 = getchar()
-    if ord(c2) != 0x5b:
+    if ord(c2) not in (0x5b, 0x4f):
         return c1 + c2
     c3 = getchar()
     if ord(c3) not in (0x31, 0x32, 0x33, 0x35, 0x36):

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -13,8 +13,7 @@ if sys.platform.startswith('linux'):
 elif sys.platform == 'darwin':
     from .readchar_linux import readchar, get_char
 elif sys.platform in ('win32', 'cygwin'):
-    from .readchar_windows import readchar
-    get_char = None
+    from .readchar_windows import readchar, get_char
 else:
     raise NotImplemented('The platform %s is not supported yet' % sys.platform)
 

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -19,10 +19,7 @@ def get_char():
     # added a timer so that it will not prematurely return a plain ESC
     #start_read = time.time()
     while True:
-        if charbuffer in key.ESCAPE_SEQUENCES:
-            char1 = readchar(False)
-        else:
-            char1 = readchar()
+        char1 = readchar()
             # start_read = time.time()
 
         # return if escape sequence is finished (or not an escape sequence).

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -7,6 +7,7 @@
 
 
 import sys
+import time
 import os
 import termios
 import fcntl
@@ -15,11 +16,14 @@ from . import key
 
 def get_char():
     charbuffer = ''
+    # added a timer so that it will not prematurely return a plain ESC
+    start_read = time.time()
     while True:
         if charbuffer in key.ESCAPE_SEQUENCES:
             char1 = readchar(False)
         else:
             char1 = readchar()
+            start_read = time.time()
 
         # return if escape sequence is finished (or not an escape sequence).
         if (charbuffer + char1) not in key.ESCAPE_SEQUENCES:
@@ -30,7 +34,8 @@ def get_char():
         # such as a plain old 'ESC' (\x1b) that is not followed by other
         # codes:
         if (charbuffer + char1) == charbuffer:
-            return charbuffer
+            if (time.time() - start_read) > .3:
+                return charbuffer
 
         # add character to sequence and continue loop...
         charbuffer += char1

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -28,7 +28,8 @@ def get_char():
         # return if escape sequence is finished (or not an escape sequence).
         if (charbuffer + char1) not in key.ESCAPE_SEQUENCES:
             # escape sequence complete or not an escape character..
-            return charbuffer + char1
+            if (charbuffer + char1) != '\x1b':
+                return charbuffer + char1
 
         # handle cases where the steam finished, but looks incomplete -
         # such as a plain old 'ESC' (\x1b) that is not followed by other

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -14,7 +14,7 @@ from . import key
 
 
 def get_char():
-    charbuffer = ''
+    charbuffer = b''
     while True:
         if charbuffer in key.ESCAPE_SEQUENCES:
             char1 = readchar(False)
@@ -46,9 +46,9 @@ def readchar(blocking=True):
 
     oldflags = fcntl.fcntl(fd, fcntl.F_GETFL)
     fcntl.fcntl(fd, fcntl.F_SETFL, oldflags | os.O_NONBLOCK)
-    c = ''
+    c = b''
     try:
-        while blocking and c == '':
+        while blocking and c == b'':
             try:
                 c = sys.stdin.read(1)
                 break

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -34,7 +34,7 @@ def get_char():
         # such as a plain old 'ESC' (\x1b) that is not followed by other
         # codes:
         if (charbuffer + char1) == charbuffer:
-            if (time.time() - start_read) > .3:
+            if (time.time() - start_read) > 1:
                 return charbuffer
 
         # add character to sequence and continue loop...

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -14,7 +14,7 @@ from . import key
 
 
 def get_char():
-    charbuffer = b''
+    charbuffer = ''
     while True:
         if charbuffer in key.ESCAPE_SEQUENCES:
             char1 = readchar(True)
@@ -46,11 +46,16 @@ def readchar(blocking=True):
 
     oldflags = fcntl.fcntl(fd, fcntl.F_GETFL)
     fcntl.fcntl(fd, fcntl.F_SETFL, oldflags | os.O_NONBLOCK)
-    c = b''
+    c = ''
     try:
-        while blocking and c == b'':
+        while blocking and c == '':
             try:
                 c = sys.stdin.read(1)
+
+                # For some  reason, this is needed for Python 3:
+                if c == '':
+                    continue
+
                 break
             except IOError:
                 pass

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -16,17 +16,17 @@ from . import key
 def get_char():
     charbuffer = b''
     while True:
-        # if charbuffer in key.ESCAPE_SEQUENCES:
-        #     char1 = readchar(False)
-        # else:
-        char1 = readchar()
+        if charbuffer in key.ESCAPE_SEQUENCES:
+            char1 = readchar(True)
+        else:
+            char1 = readchar()
 
         # return if escape sequence is finished (or not an escape sequence).
         if (charbuffer + char1) not in key.ESCAPE_SEQUENCES:
             # escape sequence complete or not an escape character..
             return charbuffer + char1
 
-        # handle cases where the escape is finished, but looks incomplete -
+        # handle cases where the steam finished, but looks incomplete -
         # such as a plain old 'ESC' (\x1b) that is not followed by other
         # codes:
         if (charbuffer + char1) == charbuffer:

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -15,7 +15,7 @@ from . import key
 
 def get_char(test_stream=None):
     charbuffer = ''
-    readstream = readchar
+    readstream = read_char
 
     if test_stream:
         def altreader(*args):
@@ -43,7 +43,7 @@ def get_char(test_stream=None):
         charbuffer += char1
 
 
-def readchar(blocking=True):
+def read_char(blocking=True):
     fd = sys.stdin.fileno()
     oldterm = termios.tcgetattr(fd)
 

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -16,10 +16,10 @@ from . import key
 def get_char():
     charbuffer = b''
     while True:
-        if charbuffer in key.ESCAPE_SEQUENCES:
-            char1 = readchar(False)
-        else:
-            char1 = readchar()
+        # if charbuffer in key.ESCAPE_SEQUENCES:
+        #     char1 = readchar(False)
+        # else:
+        char1 = readchar()
 
         # return if escape sequence is finished (or not an escape sequence).
         if (charbuffer + char1) not in key.ESCAPE_SEQUENCES:

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -16,28 +16,25 @@ from . import key
 
 def get_char():
     charbuffer = ''
-    # added a timer so that it will not prematurely return a plain ESC
-    #start_read = time.time()
     while True:
-        char1 = readchar()
-            # start_read = time.time()
+        if charbuffer in key.ESCAPE_SEQUENCES:
+            char1 = readchar(False)
+        else:
+            char1 = readchar()
 
         # return if escape sequence is finished (or not an escape sequence).
         if (charbuffer + char1) not in key.ESCAPE_SEQUENCES:
             # escape sequence complete or not an escape character..
-            if (charbuffer + char1) != '\x1b':
-                return charbuffer + char1
+            return charbuffer + char1
 
         # handle cases where the steam finished, but looks incomplete -
         # such as a plain old 'ESC' (\x1b) that is not followed by other
         # codes:
-        # if (charbuffer + char1) == charbuffer:
-         #   if (time.time() - start_read) > 1:
-          #      return charbuffer
+        if (charbuffer + char1) == charbuffer:
+            return charbuffer
 
         # add character to sequence and continue loop...
         charbuffer += char1
-        # start_read = time.time()
 
 
 def readchar(blocking=True):

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -15,11 +15,18 @@ from . import key
 
 def get_char(test_stream=None):
     charbuffer = ''
+    readstream = readchar
+    
+    if test_stream:
+        def altreader(*args):
+            return test_stream()
+        readstream = altreader
+
     while True:
         if charbuffer in key.ESCAPE_SEQUENCES:
-            char1 = str(test_stream) or readchar(False)
+            char1 = readstream(False)
         else:
-            char1 = str(test_stream) or readchar()
+            char1 = readstream()
 
         # return if escape sequence is finished (or not an escape sequence).
         if (charbuffer + char1) not in key.ESCAPE_SEQUENCES:

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -17,13 +17,13 @@ from . import key
 def get_char():
     charbuffer = ''
     # added a timer so that it will not prematurely return a plain ESC
-    start_read = time.time()
+    #start_read = time.time()
     while True:
         if charbuffer in key.ESCAPE_SEQUENCES:
             char1 = readchar(False)
         else:
             char1 = readchar()
-            start_read = time.time()
+            # start_read = time.time()
 
         # return if escape sequence is finished (or not an escape sequence).
         if (charbuffer + char1) not in key.ESCAPE_SEQUENCES:
@@ -33,12 +33,13 @@ def get_char():
         # handle cases where the steam finished, but looks incomplete -
         # such as a plain old 'ESC' (\x1b) that is not followed by other
         # codes:
-        if (charbuffer + char1) == charbuffer:
-            if (time.time() - start_read) > 1:
-                return charbuffer
+        # if (charbuffer + char1) == charbuffer:
+         #   if (time.time() - start_read) > 1:
+          #      return charbuffer
 
         # add character to sequence and continue loop...
         charbuffer += char1
+        # start_read = time.time()
 
 
 def readchar(blocking=True):

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -16,7 +16,7 @@ from . import key
 def get_char(test_stream=None):
     charbuffer = ''
     readstream = readchar
-    
+
     if test_stream:
         def altreader(*args):
             return test_stream()

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -1,23 +1,66 @@
 # -*- coding: utf-8 -*-
-# This file is based on this gist:
-# http://code.activestate.com/recipes/134892/
-# So real authors are DannyYoo and company.
+# Copyright (c) 2014 - 2017 Miguel Ángel García (@magmax9).
+# Licensed under the MIT license.
+# This code based on code snippet from the python 2 docs:
+# https://docs.python.org/2/faq/library.html
+#     #how-do-i-get-a-single-keypress-at-a-time
+
 
 import sys
-import tty
+import os
 import termios
+import fcntl
+from . import key
 
 
-def readchar():
+def get_char():
+    charbuffer = ''
+    while True:
+        if charbuffer in key.ESCAPE_SEQUENCES:
+            char1 = readchar(False)
+        else:
+            char1 = readchar()
+
+        # return if escape sequence is finished (or not an escape sequence).
+        if (charbuffer + char1) not in key.ESCAPE_SEQUENCES:
+            # escape sequence complete or not an escape character..
+            return charbuffer + char1
+
+        # handle cases where the escape is finished, but looks incomplete -
+        # such as a plain old 'ESC' (\x1b) that is not followed by other
+        # codes:
+        if (charbuffer + char1) == charbuffer:
+            return charbuffer
+
+        # add character to sequence and continue loop...
+        charbuffer += char1
+
+
+def readchar(blocking=True):
     fd = sys.stdin.fileno()
-    old_settings = termios.tcgetattr(fd)
+    oldterm = termios.tcgetattr(fd)
+
+    newattr = termios.tcgetattr(fd)
+    newattr[3] = newattr[3] & ~termios.ICANON & ~termios.ECHO
+    termios.tcsetattr(fd, termios.TCSANOW, newattr)
+
+    oldflags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, oldflags | os.O_NONBLOCK)
+    c = ''
     try:
-        tty.setraw(sys.stdin.fileno())
-        ch = sys.stdin.read(1)
+        while blocking and c == '':
+            try:
+                c = sys.stdin.read(1)
+                break
+            except IOError:
+                pass
+        else:
+            if not blocking:
+                try:
+                    c = sys.stdin.read(1)
+                except IOError:
+                    pass
     finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-
-    # useful for debugging and viewing codes
-    # print(ch, ord(ch).__hex__())
-
-    return ch
+        termios.tcsetattr(fd, termios.TCSAFLUSH, oldterm)
+        fcntl.fcntl(fd, fcntl.F_SETFL, oldflags)
+    return c

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -17,9 +17,9 @@ def get_char(test_stream=None):
     charbuffer = ''
     while True:
         if charbuffer in key.ESCAPE_SEQUENCES:
-            char1 = test_stream or readchar(False)
+            char1 = str(test_stream) or readchar(False)
         else:
-            char1 = test_stream or readchar()
+            char1 = str(test_stream) or readchar()
 
         # return if escape sequence is finished (or not an escape sequence).
         if (charbuffer + char1) not in key.ESCAPE_SEQUENCES:

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -17,7 +17,7 @@ def get_char():
     charbuffer = ''
     while True:
         if charbuffer in key.ESCAPE_SEQUENCES:
-            char1 = readchar(True)
+            char1 = readchar(False)
         else:
             char1 = readchar()
 

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -7,20 +7,19 @@
 
 
 import sys
-import time
 import os
 import termios
 import fcntl
 from . import key
 
 
-def get_char():
+def get_char(test_stream=None):
     charbuffer = ''
     while True:
         if charbuffer in key.ESCAPE_SEQUENCES:
-            char1 = readchar(False)
+            char1 = test_stream or readchar(False)
         else:
-            char1 = readchar()
+            char1 = test_stream or readchar()
 
         # return if escape sequence is finished (or not an escape sequence).
         if (charbuffer + char1) not in key.ESCAPE_SEQUENCES:

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -8,7 +8,6 @@ import tty
 import termios
 
 
-
 def readchar():
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
-# Initially taken from:
+# This file is based on this gist:
 # http://code.activestate.com/recipes/134892/
-# Thanks to Danny Yoo
+# So real authors are DannyYoo and company.
+
 import sys
 import tty
 import termios
+
 
 
 def readchar():
@@ -15,4 +17,8 @@ def readchar():
         ch = sys.stdin.read(1)
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+    # useful for debugging and viewing codes
+    # print(ch, ord(ch).__hex__())
+
     return ch

--- a/readchar/readchar_windows.py
+++ b/readchar/readchar_windows.py
@@ -6,7 +6,7 @@ import msvcrt
 
 
 def readchar(blocking=False):
-    "Get a single character on Windows."
+    """Get a single character on Windows."""
 
     while msvcrt.kbhit():
         msvcrt.getch()

--- a/readchar/readchar_windows.py
+++ b/readchar/readchar_windows.py
@@ -9,35 +9,14 @@
 
 import msvcrt
 
-from .key import windows_keys, windows_special_keys
 
+def readchar(blocking=False):
+    """Get a single character on Windows."""
 
-def get_char():
-    """Get a linux character representation on Windows.  This
-    representation will, for limited number of characters,
-    be in the standard linux ^[[A type format and can
-    be examined using the (for example) key.UP constant(s).
-    """
+    while msvcrt.kbhit():
+        msvcrt.getch()
     ch = msvcrt.getch()
-    if ch in b'\x00\xe0':
+    while ch.decode() in '\x00\xe0':
+        msvcrt.getch()
         ch = msvcrt.getch()
-        ch = repr(ch)[2:-1]
-        ch = windows_special_keys.get(ch, ch)
-    else:
-        ch = repr(ch)[2:-1]
-    if str(ch)[0] == '\\' or ch == ' ':
-        ch = windows_keys.get(ch, ch)
-    return ch
-
-
-def readchar(blocking=True):
-    """gets a character or combo on windows and returns a string. If
-    blocking is True then it will catch ctrl+c and not have them end
-    the program. It will also wait for a key to be pressed before
-    continuing on with the loop."""
-
-    if blocking:
-        return get_char()
-    else:
-        if msvcrt.kbhit():
-            return get_char()
+    return ch.decode()

--- a/readchar/readchar_windows.py
+++ b/readchar/readchar_windows.py
@@ -1,17 +1,43 @@
 # -*- coding: utf-8 -*-
-# Initially taken from:
+# Copyright (c) 2014 - 2017 Miguel Ángel García (@magmax9).
+# Licensed under the MIT license.
+# Inspired by:
 # http://code.activestate.com/recipes/134892/#c9
-# Thanks to Stephen Chappell
+# Thanks to Stephen Chappell (and  more recently,
+#  guiweber - https://github.com/guiweber)
+
+
 import msvcrt
 
+from .key import windows_keys, windows_special_keys
 
-def readchar(blocking=False):
-    """Get a single character on Windows."""
 
-    while msvcrt.kbhit():
-        msvcrt.getch()
+def get_char():
+    """Get a linux character representation on Windows.  This
+    representation will, for limited number of characters,
+    be in the standard linux ^[[A type format and can
+    be examined using the (for example) key.UP constant(s).
+    """
     ch = msvcrt.getch()
-    while ch.decode() in '\x00\xe0':
-        msvcrt.getch()
+    if ch in b'\x00\xe0':
         ch = msvcrt.getch()
-    return ch.decode()
+        ch = repr(ch)[2:-1]
+        ch = windows_special_keys.get(ch, ch)
+    else:
+        ch = repr(ch)[2:-1]
+    if str(ch)[0] == '\\' or ch == ' ':
+        ch = windows_keys.get(ch, ch)
+    return ch
+
+
+def readchar(blocking=True):
+    """gets a character or combo on windows and returns a string. If
+    blocking is True then it will catch ctrl+c and not have them end
+    the program. It will also wait for a key to be pressed before
+    continuing on with the loop."""
+
+    if blocking:
+        return get_char()
+    else:
+        if msvcrt.kbhit():
+            return get_char()

--- a/readchar/readchar_windows.py
+++ b/readchar/readchar_windows.py
@@ -12,7 +12,7 @@ import msvcrt
 from .key import windows_keys, windows_special_keys
 
 
-def get_char():
+def get_char(test_stream=None):
     """Get a linux character representation on Windows.  This
     representation will, for limited number of characters,
     be in the standard linux ^[[A type format and can
@@ -27,7 +27,7 @@ def get_char():
         ch = repr(ch)[2:-1]
     if str(ch)[0] == '\\' or ch == ' ':
         ch = windows_keys.get(ch, ch)
-    return ch
+    return test_stream or ch
 
 
 def readchar(blocking=True):

--- a/readchar/readchar_windows.py
+++ b/readchar/readchar_windows.py
@@ -9,14 +9,35 @@
 
 import msvcrt
 
+from .key import windows_keys, windows_special_keys
 
-def readchar(blocking=False):
-    """Get a single character on Windows."""
 
-    while msvcrt.kbhit():
-        msvcrt.getch()
+def get_char():
+    """Get a linux character representation on Windows.  This
+    representation will, for limited number of characters,
+    be in the standard linux ^[[A type format and can
+    be examined using the (for example) key.UP constant(s).
+    """
     ch = msvcrt.getch()
-    while ch.decode() in '\x00\xe0':
-        msvcrt.getch()
+    if ch in b'\x00\xe0':
         ch = msvcrt.getch()
-    return ch.decode()
+        ch = repr(ch)[2:-1]
+        ch = windows_special_keys.get(ch, ch)
+    else:
+        ch = repr(ch)[2:-1]
+    if str(ch)[0] == '\\' or ch == ' ':
+        ch = windows_keys.get(ch, ch)
+    return ch
+
+
+def readchar(blocking=True):
+    """gets a character or combo on windows and returns a string. If
+    blocking is True then it will catch ctrl+c and not have them end
+    the program. It will also wait for a key to be pressed before
+    continuing on with the loop."""
+
+    if blocking:
+        return get_char()
+    else:
+        if msvcrt.kbhit():
+            return get_char()

--- a/readchar/readchar_windows.py
+++ b/readchar/readchar_windows.py
@@ -30,7 +30,7 @@ def get_char(test_stream=None):
     return test_stream or ch
 
 
-def readchar(blocking=True):
+def read_char(blocking=True):
     """gets a character or combo on windows and returns a string. If
     blocking is True then it will catch ctrl+c and not have them end
     the program. It will also wait for a key to be pressed before

--- a/tests/unit/test_readkey.py
+++ b/tests/unit/test_readkey.py
@@ -1,4 +1,5 @@
 import unittest
+import time
 
 from readchar import readkey
 
@@ -8,6 +9,7 @@ def readchar_fn_factory(stream):
     v = [x for x in stream]
 
     def inner():
+        time.sleep(.05)
         return v.pop(0)
     return inner
 

--- a/tests/unit/test_readkey.py
+++ b/tests/unit/test_readkey.py
@@ -1,5 +1,4 @@
 import unittest
-import time
 
 from readchar import readkey
 
@@ -9,7 +8,6 @@ def readchar_fn_factory(stream):
     v = [x for x in stream]
 
     def inner():
-        time.sleep(.05)
         return v.pop(0)
     return inner
 
@@ -32,7 +30,7 @@ class ReadKeyTest(unittest.TestCase):
 
     def test_special_combo_character(self):
         char = '\x1b\x01'
-        getchar_fn = readchar_fn_factory(char)
+        getchar_fn = readchar_fn_factory(char + 'foo')
 
         result = readkey(getchar_fn)
 

--- a/tests/unit/test_readkey.py
+++ b/tests/unit/test_readkey.py
@@ -30,7 +30,7 @@ class ReadKeyTest(unittest.TestCase):
 
     def test_special_combo_character(self):
         char = '\x1b\x01'
-        getchar_fn = readchar_fn_factory(char + 'foo')
+        getchar_fn = readchar_fn_factory(char)
 
         result = readkey(getchar_fn)
 


### PR DESCRIPTION
Based off of 0.8.0, this version successfully implements the Linux special keys including the ESC. 

- added the TAB character, which was missing.

#### For both OS types, the new readkey() now wraps a `get_char` method, which is separate from the readchar methods (which only return a character byte).  The get_char handles the reading need to get the full keystroke codes. ####

__for Linux__:
- At the heart of this is a new `reachar_linux.readchar()` that successfully implements a real blocking bahavior, allowing us to get all queued up characters after an ESC.
- This means if Escape was the only character, we can detect that now.
- Users can also use the Linux (and Windows) versions to call `readchar()` in a non-blocking manner (the default is to block, i.e. wait for a keystroke to be typed).

__for Windows__:
- I re-implemented Guiweber's windows methods, with blocking, however I don't have a windows testing platform to test or improve this section.
- It differs from his version because the readkey() returns the standard constants from key.py that are used by Linux versus the originally proposed string values (so separate comparisons are not required between OSes).
- for convenience, key.py contains a conversion function `convertchar()` to convert these back to string names like "ctrl_a", if desired.
- The constants for windows will need to be updated and improved due to being incomplete.  New items should only be added if we can create a valid byte-string constant for them.
