### PR TITLE
Fixed Windows and Python 3.6 issues

### DIFF
--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -10,21 +10,87 @@ if sys.platform.startswith('linux'):
 elif sys.platform == 'darwin':
     from .readchar_linux import readchar
 elif sys.platform in ('win32', 'cygwin'):
+    import msvcrt
     from .readchar_windows import readchar
+    from . import key
 else:
     raise NotImplemented('The platform %s is not supported yet' % sys.platform)
 
 
-def readkey(getchar_fn=None):
-    getchar = getchar_fn or readchar
-    c1 = getchar()
-    if ord(c1) != 0x1b:
-        return c1
-    c2 = getchar()
-    if ord(c2) != 0x5b:
-        return c1 + c2
-    c3 = getchar()
-    if ord(c3) != 0x33:
-        return c1 + c2 + c3
-    c4 = getchar()
-    return c1 + c2 + c3 + c4
+if sys.platform in ('win32', 'cygwin'):
+    #
+    # Windows uses scan codes for extended characters. The ordinal returned is 256 * the scan code.
+    # This dictionary translates scan codes to the unicode sequences expected by readkey.
+    #
+    # for windows scan codes see:
+    #   https://msdn.microsoft.com/en-us/library/aa299374
+    #      or
+    #   http://www.quadibloc.com/comp/scan.htm
+    xlate_dict = {
+        13: key.ENTER,
+        27: key.ESC,
+        15104: key.F1,
+        15360: key.F2,
+        15616: key.F3,
+        15872: key.F4,
+        16128: key.F5,
+        16384: key.F6,
+        16640: key.F7,
+        16896: key.F8,
+        17152: key.F9,
+        17408: key.F10,
+        22272: key.F11,
+        34528: key.F12,
+
+        7680: key.ALT_A,
+
+        # don't have table entries for...
+        # CTRL_ALT_A, # Ctrl-Alt-A, etc.
+        # CTRL_ALT_SUPR,
+        # CTRL-F1
+
+        21216: key.INSERT,
+        21472: key.SUPR,    # key.py uses SUPR, not DELETE
+        18912: key.PAGE_UP,
+        20960: key.PAGE_DOWN,
+        18400: key.HOME,
+        20448: key.END,
+
+        18656: key.UP,
+        20704: key.DOWN,
+        19424: key.LEFT,
+        19936: key.RIGHT,
+    }
+
+    def readkey(getchar_fn=None):
+        # Get a single character on Windows. if an extended key is pressed, the Windows scan
+        # code is translated into a the unicode sequences readchar expects (see key.py).
+        while True:
+            if msvcrt.kbhit():
+                ch = msvcrt.getch()
+                a = ord(ch)
+                if a == 0 or a == 224:
+                    b = ord(msvcrt.getch())
+                    x = a + (b * 256)
+
+                    try:
+                        return xlate_dict[x]
+                    except KeyError:
+                        return None
+                    return x
+                else:
+                    return ch.decode()
+else:
+    def readkey(getchar_fn=None):
+        getchar = getchar_fn or readchar
+        c1 = getchar()
+        if ord(c1) != 0x1b:
+            return c1
+        c2 = getchar()
+        if ord(c2) != 0x5b:
+            return c1 + c2
+        c3 = getchar()
+        if ord(c3) != 0x33:
+            return c1 + c2 + c3
+        c4 = getchar()
+        return c1 + c2 + c3 + c4

--- a/readchar/readchar_windows.py
+++ b/readchar/readchar_windows.py
@@ -3,6 +3,16 @@
 # http://code.activestate.com/recipes/134892/#c9
 # Thanks to Stephen Chappell
 import msvcrt
+import sys
+
+
+win_encoding = 'mbcs'
+
+
+if sys.version_info.major < 3:
+    XE0_OR_00 = unicode('\x00\xe0', win_encoding)
+else:
+    XE0_OR_00 = '\x00\xe0'
 
 
 def readchar(blocking=False):
@@ -11,7 +21,12 @@ def readchar(blocking=False):
     while msvcrt.kbhit():
         msvcrt.getch()
     ch = msvcrt.getch()
-    while ch.decode() in '\x00\xe0':
+    #print('ch={}, type(ch)={}'.format(ch, type(ch)))
+    #while ch.decode(win_encoding) in unicode('\x00\xe0', win_encoding):
+    while ch.decode(win_encoding) in XE0_OR_00:
+        #print('found x00 or xe0')
         msvcrt.getch()
         ch = msvcrt.getch()
-    return ch.decode()
+
+    return ch if sys.version_info.major > 2 else ch.decode(encoding=win_encoding)
+

--- a/test.py
+++ b/test.py
@@ -1,0 +1,43 @@
+
+import msvcrt
+import readchar.readchar
+import readchar.key
+
+
+decode_dict = {
+    readchar.key.ESC: 'ESC',
+    readchar.key.UP: 'UP',
+    readchar.key.DOWN: 'DOWN',
+    readchar.key.LEFT: 'LEFT',
+    readchar.key.RIGHT: 'RIGHT',
+    readchar.key.PAGE_UP: 'PAGE_UP',
+    readchar.key.PAGE_DOWN: 'PAGE_DOWN',
+    readchar.key.HOME: 'HOME',
+    readchar.key.END: 'END',
+    readchar.key.INSERT: 'INSERT',
+    readchar.key.SUPR: 'DELETE',
+    readchar.key.F1: 'F1',
+    readchar.key.F2: 'F2',
+    readchar.key.F3: 'F3',
+    readchar.key.F4: 'F4',
+    readchar.key.F5: 'F5',
+    readchar.key.F6: 'F6',
+    readchar.key.F7: 'F7',
+    readchar.key.F8: 'F8',
+    readchar.key.F9: 'F9',
+    readchar.key.F10: 'F10',
+    readchar.key.F12: 'F12',
+    readchar.key.ALT_A: 'ALT_A',
+}
+    
+while True:
+    c = readchar.readkey()
+
+    if c in decode_dict:
+        print ('got {}'.format(decode_dict[c]))
+    else:
+        print(c)
+
+    if c==readchar.key.ESC:
+        break
+


### PR DESCRIPTION
I made changes to readkey and readchar to work on Windows and Python 3 (particularly with encoding on Windows for Python 3.6). The keys sequences in readkey are mapped to the Linux/Mac strings so the key mappings are compatible between the two platforms.

The test program test.py shows how to use this. It echos the key code and exits when escape is hit.

Len