### PR TITLE
use setcbreak instead of setraw, fixes #53

### DIFF
--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -11,7 +11,7 @@ def readchar():
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)
     try:
-        tty.setraw(sys.stdin.fileno())
+        tty.setcbreak(sys.stdin.fileno())
         ch = sys.stdin.read(1)
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)


### PR DESCRIPTION
Tested locally, works much better. setcbreak is definitely a better option than setraw.

See https://www.tutorialspoint.com/terminal-control-functions-in-python for more info.