### PR TITLE
 Fix Enter Key Keycode

### DIFF
--- a/readchar/key.py
+++ b/readchar/key.py
@@ -1,7 +1,7 @@
 # common
-LF = "\x0d"
-CR = "\x0a"
-ENTER = "\x0d"
+LF = "\x0a"
+CR = "\x0d"
+ENTER = "\x0a"
 BACKSPACE = "\x7f"
 SUPR = ""
 SPACE = "\x20"

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -11,7 +11,7 @@ def readchar():
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)
     try:
-        tty.setraw(sys.stdin.fileno())
+        tty.setcbreak(sys.stdin.fileno())
         ch = sys.stdin.read(1)
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)

--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -11,7 +11,7 @@ def readchar():
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)
     try:
-        tty.setcbreak(sys.stdin.fileno())
+        tty.setraw(sys.stdin.fileno())
         ch = sys.stdin.read(1)
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)


### PR DESCRIPTION
As you can see in this issue (https://github.com/C0D3D3V/Moodle-Downloader-2/issues/83), since reformatting, the enter key recognition no longer works. (You can see my readkey usage here https://github.com/C0D3D3V/Moodle-Downloader-2/blob/284f84614934d6d9ca279ffdec0884d1d0cdb873/moodle_dl/utils/cutie.py#L318)

I hope that was not intentional. There has sneaked in a small change in the reformatting.