### PR TITLE
Fixed backspace and arrow support on Windows

### DIFF
--- a/readchar/key.py
+++ b/readchar/key.py
@@ -2,7 +2,7 @@
 LF = "\x0d"
 CR = "\x0a"
 ENTER = "\x0d"
-BACKSPACE = "\x7f"
+BACKSPACE = "\x08"
 SUPR = ""
 SPACE = "\x20"
 ESC = "\x1b"

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -53,10 +53,10 @@ if sys.platform in ("win32", "cygwin"):
         20960: key.PAGE_DOWN,
         18400: key.HOME,
         20448: key.END,
-        18656: key.UP,
-        20704: key.DOWN,
-        19424: key.LEFT,
-        19936: key.RIGHT,
+        18432: key.UP,      # 72 * 256
+        20480: key.DOWN,    # 80 * 256
+        19200: key.LEFT,    # 75 * 256
+        19712: key.RIGHT,   # 77 * 256
     }
 
     def readkey(getchar_fn=None):


### PR DESCRIPTION
Fixing #57, and two issues from Inquirer ([#117](https://github.com/magmax/python-inquirer/issues/117) and [#116](https://github.com/magmax/python-inquirer/issues/116)).

For #57 and Inquirer's [#116](https://github.com/magmax/python-inquirer/issues/116), I fixed the wrong code for the backspace, which should be `"\x08"` (the 'extra' bytes that appear on the string mentioned in the Inquirer's issue). This needs testing on other Windows machines to confirm, although it matches the ASCII/Extended codes on [Microsoft's guide](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-6.0/aa299374(v=vs.60)?redirectedfrom=MSDN).

For the missing arrow support [#117](https://github.com/magmax/python-inquirer/issues/117), the scan codes on `readchar.py` were wrong. I fixed them according to [Microsoft's scan codes](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-6.0/aa299374(v=vs.60)?redirectedfrom=MSDN).