### PR TITLE
Fix for reading input while script is in debug with PyCharm running on MacOS

### DIFF
--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -12,7 +12,7 @@ def readchar():
     old_settings = termios.tcgetattr(fd)
     try:
         tty.setraw(sys.stdin.fileno())
-        ch = sys.stdin.read(1)
+        ch = sys.stdin.readline(1)
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
     return ch


### PR DESCRIPTION
I notices that when we use this library with enabled debug with PyCharm on MacOS it hangs while requesting the input.
Does not matter if the script run in the PyCharm internal terminal, iTerm2 terminal or native MacOS terminal app.