### PR TITLE
Don't drop Keypresses outside of readchar_linux()

### DIFF
--- a/readchar/readchar_linux.py
+++ b/readchar/readchar_linux.py
@@ -11,7 +11,7 @@ def readchar():
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)
     try:
-        tty.setraw(sys.stdin.fileno())
+        tty.setraw(sys.stdin.fileno(), when=termios.TCSADRAIN)
         ch = sys.stdin.read(1)
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)


### PR DESCRIPTION
Calling `tty.setraw` makes it so that subsequent calls to `read()` don't read
any of the typed-but-not-read characters. Reading the code, this could be
expected since `tty.setraw` is called without explicit parameters, and the
[default for when](https://github.com/python/cpython/blob/345572a1a026/Lib/tty.py#L18)
is `TCSAFLUSH`, which means:

> If optional_actions is TCSAFLUSH, the change shall occur after all output
> written to fildes is transmitted, **and all input so far received but not
> read shall be discarded before the change is made.** (emphasis mine)

Indeed, changing the call to be with `TCSADRAIN` seems to solve the problem of
missing keystrokes.

However, that solves the problem that any keystrokes that occur outside of
`readchar` are dropped fully, but it does not solve the problem that they will
be echoed. (They will be echoed because they occur at a point in time that
stdin is in "cooked" or "canonical" (non-raw) mode).

See #73