### PR TITLE
v3.0.6 development (Quick fixes for broken v3.0.5)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - name: check YAML format
         id: yamllint
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - name: re-format with black
         id: black

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -2,7 +2,7 @@
 LF = "\x0d"
 CR = "\x0a"
 ENTER = "\x0d"
-BACKSPACE = "\x08"
+BACKSPACE = "\x7f"
 SUPR = ""
 SPACE = "\x20"
 ESC = "\x1b"

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -69,6 +69,8 @@ if sys.platform in ("win32", "cygwin"):
                         return xlate_dict[b]
                     except KeyError:
                         return None
+                elif a == 8:
+                    return key.BACKSPACE
                 else:
                     return ch.decode()
 

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -17,7 +17,7 @@ else:
     raise NotImplementedError("The platform %s is not supported yet" % sys.platform)
 
 
-if sys.platform in ("win32", "cygwin"):
+if sys.platform in ("win32", "cygwin"):  # noqa: C901
     #
     # Windows uses scan codes for extended characters. This dictionary translates
     # scan codes to the unicode sequences expected by readkey.

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -71,6 +71,8 @@ if sys.platform in ("win32", "cygwin"):
                         return None
                 elif a == 8:
                     return key.BACKSPACE
+                elif a == 13:
+                    return key.ENTER
                 else:
                     return ch.decode()
 

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -53,10 +53,10 @@ if sys.platform in ("win32", "cygwin"):
         20960: key.PAGE_DOWN,
         18400: key.HOME,
         20448: key.END,
-        18432: key.UP,  # 72 * 256
-        20480: key.DOWN,  # 80 * 256
-        19200: key.LEFT,  # 75 * 256
-        19712: key.RIGHT,  # 77 * 256
+        18656: key.UP,
+        20704: key.DOWN,
+        19424: key.LEFT,
+        19936: key.RIGHT,
     }
 
     def readkey(getchar_fn=None):

--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -19,44 +19,40 @@ else:
 
 if sys.platform in ("win32", "cygwin"):
     #
-    # Windows uses scan codes for extended characters. The ordinal returned is
-    # 256 * the scan code.  This dictionary translates scan codes to the
-    # unicode sequences expected by readkey.
+    # Windows uses scan codes for extended characters. This dictionary translates
+    # scan codes to the unicode sequences expected by readkey.
     #
     # for windows scan codes see:
     #   https://msdn.microsoft.com/en-us/library/aa299374
     #      or
     #   http://www.quadibloc.com/comp/scan.htm
     xlate_dict = {
-        13: key.ENTER,
-        27: key.ESC,
-        15104: key.F1,
-        15360: key.F2,
-        15616: key.F3,
-        15872: key.F4,
-        16128: key.F5,
-        16384: key.F6,
-        16640: key.F7,
-        16896: key.F8,
-        17152: key.F9,
-        17408: key.F10,
-        22272: key.F11,
-        34528: key.F12,
-        7680: key.ALT_A,
+        59: key.F1,
+        60: key.F2,
+        61: key.F3,
+        62: key.F4,
+        63: key.F5,
+        64: key.F6,
+        65: key.F7,
+        66: key.F8,
+        67: key.F9,
+        68: key.F10,
+        133: key.F11,
+        134: key.F12,
         # don't have table entries for...
         # CTRL_ALT_A, # Ctrl-Alt-A, etc.
         # CTRL_ALT_SUPR,
-        # CTRL-F1
-        21216: key.INSERT,
-        21472: key.SUPR,  # key.py uses SUPR, not DELETE
-        18912: key.PAGE_UP,
-        20960: key.PAGE_DOWN,
-        18400: key.HOME,
-        20448: key.END,
-        18656: key.UP,
-        20704: key.DOWN,
-        19424: key.LEFT,
-        19936: key.RIGHT,
+        # CTRL_ALT_A, .., etc.
+        82: key.INSERT,
+        83: key.SUPR,  # key.py uses SUPR, not DELETE
+        73: key.PAGE_UP,
+        81: key.PAGE_DOWN,
+        71: key.HOME,
+        79: key.END,
+        72: key.UP,
+        80: key.DOWN,
+        75: key.LEFT,
+        77: key.RIGHT,
     }
 
     def readkey(getchar_fn=None):
@@ -69,13 +65,10 @@ if sys.platform in ("win32", "cygwin"):
                 a = ord(ch)
                 if a == 0 or a == 224:
                     b = ord(msvcrt.getch())
-                    x = a + (b * 256)
-
                     try:
-                        return xlate_dict[x]
+                        return xlate_dict[b]
                     except KeyError:
                         return None
-                    return x
                 else:
                     return ch.decode()
 

--- a/test.py
+++ b/test.py
@@ -26,6 +26,7 @@ decode_dict = {
     readchar.key.F12: "F12",
     readchar.key.ALT_A: "ALT_A",
     readchar.key.BACKSPACE: "BACKSPACE",
+    readchar.key.ENTER: "ENTER",
 }
 
 while True:

--- a/test.py
+++ b/test.py
@@ -25,6 +25,7 @@ decode_dict = {
     readchar.key.F10: "F10",
     readchar.key.F12: "F12",
     readchar.key.ALT_A: "ALT_A",
+    readchar.key.BACKSPACE: "BACKSPACE",
 }
 
 while True:


### PR DESCRIPTION
As #71 is quite complex and introduces some braking changes, I also provide this PR to just fixes the immediate problems and roll out a new version to replace the broken Version 3.0.5. This should take care of #75 and the multitude of linked issues on #66 and #71

## Changes

This PR reverts the bad PR #65, which broke BACKSPACE for Linux systems as well as making the windows scancode lookuptable more inconsistent (see [here](https://github.com/magmax/python-readchar/pull/65#issuecomment-966620512) and #66).

The wrong BACKSPACE code is addressed by a separate check on the windows side, same for ENTER, which is also different on Windows. The lookuptable is completed with the missing values, fixing the inconsistencies.

I bumped black in the pre-commit-config.yaml as 22.1.0 is broken and would not run

~~I removed Python 2.7 and pypy from the list of supported version, as it is no longer tested and probably doesn't work.~~ I reverted this as it should be handled as part of the v4 release in my opinion.

## Problems

The pre-commit test won't complete, as the if statement contaning all of the windows code is to complex. But as this is only suppoesed to be a quick fix before v4.0 I wound't bother with that. 


closes #75
closes #57 