### PR TITLE
Add support for FreeBSD.

### DIFF
--- a/readchar/readchar.py
+++ b/readchar/readchar.py
@@ -8,6 +8,8 @@ if sys.platform.startswith("linux"):
     from .readchar_linux import readchar
 elif sys.platform == "darwin":
     from .readchar_linux import readchar
+elif sys.platform.startswith("freebsd"):
+    from .readchar_linux import readchar
 elif sys.platform in ("win32", "cygwin"):
     import msvcrt
 


### PR DESCRIPTION
Use `readchar_linux` on FreeBSD too, like on Linux and Darwin. This seems to run fine.