### PR TITLE
import key submodule into __init__

### DIFF
--- a/readchar/__init__.py
+++ b/readchar/__init__.py
@@ -12,7 +12,9 @@ if (
     or platform.startswith("freebsd")
 ):
     from ._posix_read import readchar, readkey
+    from . import _posix_key as key
 elif platform in ("win32", "cygwin"):
     from ._win_read import readchar, readkey
+    from . import _win_key as key
 else:
     raise NotImplementedError(f"The platform {platform} is not supported yet")

--- a/readchar/key.py
+++ b/readchar/key.py
@@ -1,4 +1,6 @@
 # flake8: noqa E401,E403
+# this file exists only for backwards compatability
+# it allow the use of `import readchar.key`
 
 from . import platform
 

--- a/tests/posix/test_import.py
+++ b/tests/posix/test_import.py
@@ -11,6 +11,5 @@ def test_readkeyImport():
 
 def test_keyImport():
     a = {k: v for k, v in vars(readchar.key).items() if not k.startswith("__")}
-    del a["platform"]
     b = {k: v for k, v in vars(readchar._posix_key).items() if not k.startswith("__")}
     assert a == b

--- a/tests/windows/test_import.py
+++ b/tests/windows/test_import.py
@@ -11,6 +11,5 @@ def test_readkeyImport():
 
 def test_keyImport():
     a = {k: v for k, v in vars(readchar.key).items() if not k.startswith("__")}
-    del a["platform"]
     b = {k: v for k, v in vars(readchar._win_key).items() if not k.startswith("__")}
     assert a == b


### PR DESCRIPTION
fixes #87

now all possible import options work:

- [x] works:
    ```python
    import readchar
    print(readchar.key.UP)
    ```

- [x] works:
    ```python
    import readchar.key
    print(readchar.key.UP)
    ```

- [x] works:
    ```python
    import readchar.key as keys
    print(keys.UP)
    ```
- [x] works:
    ```python
    from readchar import key
    print(key.UP)
    ```