### PR TITLE
include `py.typed` in package

### DIFF
--- a/readchar/__init__.py
+++ b/readchar/__init__.py
@@ -1,6 +1,6 @@
 """Library to easily read single chars and key strokes"""
 
-__version__ = "4.0.4-dev1"
+__version__ = "4.0.4-dev2"
 __all__ = ["readchar", "readkey", "key", "config"]
 
 from sys import platform

--- a/readchar/__init__.py
+++ b/readchar/__init__.py
@@ -1,6 +1,6 @@
 """Library to easily read single chars and key strokes"""
 
-__version__ = "4.0.4-dev0"
+__version__ = "4.0.4-dev1"
 __all__ = ["readchar", "readkey", "key", "config"]
 
 from sys import platform

--- a/readchar/__init__.py
+++ b/readchar/__init__.py
@@ -1,6 +1,6 @@
 """Library to easily read single chars and key strokes"""
 
-__version__ = "4.0.4-dev2"
+__version__ = "4.0.4-dev3"
 __all__ = ["readchar", "readkey", "key", "config"]
 
 from sys import platform

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ packages = find:
 install_requires =
     setuptools>=41.0
 python_requires = >=3.6
+include_package_data = True
 
 [options.packages.find]
 exclude =
@@ -48,6 +49,10 @@ exclude =
     .github/
     .venv/
     tests/
+
+[options.package_data]
+readchar =
+    py.typed
 
 [tool:pytest]
 testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,9 @@ project_urls =
 packages = find:
 install_requires =
     setuptools>=41.0
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
+zip_safe = false
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
this should enable mypy to analyse the package and fix #100

@phoenixr-codes can you please confirm this fixes the issue? Use this to install the pre-release version:

```bash
pip install -U --pre readchar==4.0.4.dev0
``` 