### PR TITLE
Fix characters being dropped from the input stream

### DIFF
--- a/readchar/_posix_read.py
+++ b/readchar/_posix_read.py
@@ -19,7 +19,7 @@ def readchar() -> str:
     term = termios.tcgetattr(fd)
     try:
         term[3] &= ~(termios.ICANON | termios.ECHO | termios.IGNBRK | termios.BRKINT)
-        termios.tcsetattr(fd, termios.TCSAFLUSH, term)
+        termios.tcsetattr(fd, termios.TCSADRAIN, term)
 
         ch = sys.stdin.read(1)
     finally:


### PR DESCRIPTION
TCSADRAIN is the same as TCSAFLUSH, except TCSADRAIN does not discard queued input

Keypresses that occur inbetween calls to readchar are queued, so discarding causes the keypresses to be lost. This fixes #73 