### PR TITLE
Fix pytest 9 compatibility

### DIFF
--- a/tests/linux/conftest.py
+++ b/tests/linux/conftest.py
@@ -8,7 +8,7 @@ if sys.platform.startswith("linux"):
 
 
 # ignore all tests in this folder if not on linux
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(collection_path, config):
     if not sys.platform.startswith("linux"):
         return True
 

--- a/tests/windows/conftest.py
+++ b/tests/windows/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 
 # ignore all tests in this folder if not on windows
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(collection_path, config):
     if sys.platform not in ("win32", "cygwin"):
         return True
 


### PR DESCRIPTION
The path argument has been deprecated in favor of the collection_path argument beecause the former uses the deprecated py library, where the latter uses pathlib.

https://docs.pytest.org/en/7.1.x/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
