### PR TITLE
Add android as supported platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Some operating systems are enabled, but not actively tested or supported:
 
 - macOS
 - FreeBSD / OpenBSD
-- Termux
+- Android
 
 Theoretically every Unix based system should work, but they will not be actively tested.
 It is also required that somebody provides initial test results before the OS is enabled

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Some operating systems are enabled, but not actively tested or supported:
 
 - macOS
 - FreeBSD / OpenBSD
+- Termux
 
 Theoretically every Unix based system should work, but they will not be actively tested.
 It is also required that somebody provides initial test results before the OS is enabled

--- a/readchar/__init__.py
+++ b/readchar/__init__.py
@@ -11,7 +11,7 @@ from sys import platform
 from ._config import config
 
 
-if platform.startswith(("linux", "darwin", "freebsd", "openbsd")):
+if platform.startswith(("linux", "darwin", "freebsd", "openbsd", "android")):
     from . import _posix_key as key
     from ._posix_read import readchar, readkey
 elif platform in ("win32", "cygwin"):


### PR DESCRIPTION
Python 3.13 changed the value returned by `sys.platform()` to now return `android`, instead of `linux`, on Android (such as via Termux)